### PR TITLE
fix c99 compiling error

### DIFF
--- a/SGXSpectre/main/main.c
+++ b/SGXSpectre/main/main.c
@@ -62,7 +62,8 @@ uint8_t array2[256 * 512];
 		training_x = tries % array1_size;
 		for (j = 29; j >= 0; j--) {
 			_mm_clflush(&array1_size);
-			for (volatile int z = 0; z < 100; z++) {} /* Delay (can also mfence) */
+			volatile int z;
+			for (z = 0; z < 100; z++) {} /* Delay (can also mfence) */
 			
 			/* Bit twiddling to set x=training_x if j%6!=0 or malicious_x if j%6==0 */
 			/* Avoid jumps in case those tip off the branch predictor */


### PR DESCRIPTION
root@sgx2-HP-ENVY-x360-m6-Convertible:~/git/spectre-attack-sgx/SGXSpectre# make
cd main && /opt/intel/sgxsdk/bin/x64/sgx_edger8r --untrusted ../enclave/enclave.edl --search-path ../enclave --search-path /opt/intel/sgxsdk/include
GEN  =>  enclave_u.c
cd main && gcc -m64 -g -O2 -fPIC -Wno-attributes -Wno-implicit-function-declaration  -DNDEBUG -DEDEBUG -UDEBUG -I/opt/intel/sgxsdk/include -c enclave_u.c -o enclave_u.o
CC   <=  enclave_u.c
cd main && gcc -g -O2 -fPIC -DPIC -Werror -m64 -g -O2 -fPIC -Wno-attributes -Wno-implicit-function-declaration  -DNDEBUG -DEDEBUG -UDEBUG -I/opt/intel/sgxsdk/include -c main.c -o main.o
main.c: In function ‘readMemoryByte’:
main.c:65:4: error: ‘for’ loop initial declarations are only allowed in C99 mode
    for (volatile int z = 0; z < 100; z++) {} /* Delay (can also mfence) */
    ^
main.c:65:4: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [main.o] Error 1
root@sgx2-HP-ENVY-x360-m6-Convertible:~/git/spectre-attack-sgx/SGXSpectre# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/4.8/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 4.8.4-2ubuntu1~14.04.3' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3)
root@sgx2-HP-ENVY-x360-m6-Convertible:~/git/spectre-attack-sgx/SGXSpectre#